### PR TITLE
Add enabling HDMI even when not plugged in at boot

### DIFF
--- a/image_recipe.md
+++ b/image_recipe.md
@@ -238,6 +238,18 @@ sudo apt-get remove mycroft-core
 sudo apt-get remove avrdude libftdi1
 sudo rm -rf /opt/venv
 
+## Force HDMI on 
+`sudo nano /boot/config.txt`
+Uncomment `hdmi_force_hotplug=1` and `hdmi_drive=2`
+
+# Force mode to HDMI 1024x768
+Uncomment/edit:
+```
+hdmi_group=2
+hdmi_mode=16
+```
+NOTE:  Leaving these alone will default to VGA when you connect the monitor after the fact, but it will also pick the highest supported mode automatically.  So this is a trade off.
+
 ## Disable the auto-update of Debian
 sudo nano /etc/cron.hourly/mycroft-core
    comment out "apt-get install..." for now


### PR DESCRIPTION
By default, Raspbian will disable the HDMI output unless there is a monitor detected at boot time.  This makes debugging tricky at times.  This change forces the HDMI to be on and forces an HDMI mode of 1024x768 @ 60 Mhz.  The vast majority of monitors support this mode.
