### PR TITLE
Remove unnecessary config values

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -4,6 +4,6 @@
   "enclosure": {
     "platform": "mycroft_mark_2pi",
     "platform_build": 1
-  }
+  },
   "ipc_path": "/ramdisk/mycroft/ipc/"
 }


### PR DESCRIPTION
Stripped mycroft.conf to the bare minimum of settings for the Mark 2 Raspberry pi.
