### PR TITLE
Startup pulseaudio before mycroft

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -1,6 +1,4 @@
 {
-  "play_wav_cmdline": "aplay -Dplughw:ArrayUAC10,0 %1",
-  "play_mp3_cmdline": "mpg123 -a plughw:ArrayUAC10,0 %1",
   "enclosure": {
     "platform": "mycroft_mark_2pi",
     "platform_build": 1

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -839,6 +839,11 @@ then
         cd ~
     fi
 
+    # Launch pulseaudio if needed
+    if ! pidof pulseaudio > /dev/null; then
+        pulseaudio -D
+        sleep 1
+    fi
     # Launch Mycroft Services ======================
     bash "$HOME/mycroft-core/start-mycroft.sh" all
 else


### PR DESCRIPTION
This registers the default device to alsa and handles the mic and
speaker correctly by default allowing thirdparty audio applications to
work better without additional config.

