### PR TITLE
Unload module-suspend-on-idle

### DIFF
--- a/home/pi/.config/pulse/default.pa
+++ b/home/pi/.config/pulse/default.pa
@@ -1,0 +1,2 @@
+.include /etc/pulse/default.pa
+unload-module module-suspend-on-idle


### PR DESCRIPTION
This should remove or at least reduce popping (ref: https://wiki.archlinux.org/index.php/PulseAudio/Troubleshooting#Pops_when_starting_and_stopping_playback)

