### PR TITLE
Add skill-mark-2-pi to list of priority skills

### DIFF
--- a/etc/mycroft/mycroft.conf
+++ b/etc/mycroft/mycroft.conf
@@ -12,6 +12,9 @@
       }
     }
   },
+  "skills": {
+    "priority_skills": ["skill-mark2-pi.mycroftai", "mycroft-pairing", "mycroft-volume"]
+  },
   "log_level": "DEBUG",
   "ipc_path": "/ramdisk/mycroft/ipc/"
 }


### PR DESCRIPTION
Add `skill-mark-2-pi.mycroftai` to the list to make sure it's loaded before the pairing sequence starts so pairing code can be shown on screen.