### PR TITLE
Pandora audio support

### DIFF
--- a/etc/libao.conf
+++ b/etc/libao.conf
@@ -1,0 +1,2 @@
+default_driver=pulse
+quiet

--- a/home/pi/setup.sh
+++ b/home/pi/setup.sh
@@ -52,6 +52,10 @@ sudo echo "default-sample-format = s24le" | sudo tee -a /etc/pulse/daemon.conf
 sudo echo "default-sample-rate = 48000" | sudo tee -a /etc/pulse/daemon.conf
 sudo echo "alternate-sample-rate = 44100" | sudo tee -a /etc/pulse/daemon.conf
 
+cd /etc
+sudo wget -N $REPO_PATH/etc/libao.conf
+cd ~
+
 # Display Setup
 sudo echo "# Mark 2 Pi Display Settings" | sudo tee -a /boot/config.txt    
 sudo echo "hdmi_force_hotplug=1" | sudo tee -a /boot/config.txt
@@ -82,6 +86,7 @@ sudo raspi-config nonint do_i2c 0
 sudo mkdir -p /etc/udev/rules.d
 cd /etc/udev/rules.d
 sudo wget -N $REPO_PATH/etc/udev/rules.d/98-mic-array.rules
+cd ~
 
 # Get the Picroft conf file
 cd /etc/mycroft


### PR DESCRIPTION
Fixes Pandora playback on Mark 2 Pi

To test just replace `oss` in `/etc/libao.conf` with `pulse` as the default driver. The Pandora should work. If not you might need to pull this change as well https://github.com/MycroftAI/pianobar-skill/pull/30.