### PR TITLE
Mic watchdog

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -51,7 +51,7 @@ then
 
     # Launch Mycroft Services ======================
     bash "$HOME/mycroft-core/start-mycroft.sh" all > /dev/null 2>&1
-    python mic_monitor.py >> /var/log/mycroft/mic-watchdog.log  2>&1 &
+    python mic_monitor.py >> /var/log/mycroft/mic_monitor.log  2>&1 &
 else
     # running in SSH session
     echo

--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -51,6 +51,7 @@ then
 
     # Launch Mycroft Services ======================
     bash "$HOME/mycroft-core/start-mycroft.sh" all > /dev/null 2>&1
+    python mic_monitor.py >> /var/log/mycroft/mic-watchdog.log  2>&1 &
 else
     # running in SSH session
     echo

--- a/home/pi/mic_monitor.py
+++ b/home/pi/mic_monitor.py
@@ -1,0 +1,77 @@
+from logging import (
+    basicConfig,
+    getLogger,
+    DEBUG,
+    Formatter,
+    StreamHandler
+)
+from os.path import getmtime, exists
+from time import time, sleep
+from subprocess import call
+import sys
+
+def configure_logger():
+    logger = getLogger()
+    logger.level = DEBUG
+    formatter = Formatter(
+        '{asctime} | {levelname:8} | {process:5} | {name} | {message}',
+        style='{'
+    )
+    formatter.default_msec_format = '%s.%03d'
+    handler = StreamHandler(sys.stdout)
+    handler.setLevel(DEBUG)
+    handler.setFormatter(formatter)
+    logger.addHandler(handler)
+
+LOG = getLogger(__name__)
+
+class MicrophoneMonitor:
+    def __init__(self):
+        self.mic_level_path = '/ramdisk/mycroft/ipc/mic_level'
+        self.restart_voice_command = (
+                '/home/pi/mycroft-core/start-mycroft.sh',
+                'voice',
+                'restart'
+            )
+        self.interval = 60
+        self.startup_delay = 60
+
+    def running(self):
+        """
+        Consider the mic input to be working if the mic_level file has been
+        modified in the last minute.
+        """
+        return (
+            exists(self.mic_level_path) and 
+            time() < getmtime(self.mic_level_path) + 60
+        )
+
+    def muted(self):
+        """
+        Read muted state from mic level file.
+        It looks like 'muted=0' at the end of the file.
+        """ 
+        with open(self.mic_level_path) as f:
+            text = f.read()
+            muted = int(text.split('=')[-1])
+        return muted
+
+    def restart_voice_process(self):
+        call(self.restart_voice_command)
+
+    def run(self):
+        while True:
+            try:
+                sleep(self.interval)
+                if not self.running() and not self.muted():
+                    LOG.info('Mic seems to be frozen! Restarting voice process...')
+                    self.restart_voice_process()
+                    sleep(self.startup_delay)  # Give startup some extra time to complete
+            except Exception as e:
+                LOG.exception('Mic check failed.')
+
+if __name__ == '__main__':
+    configure_logger()
+    mic_monitor = MicrophoneMonitor()
+    mic_monitor.run()
+

--- a/home/pi/setup.sh
+++ b/home/pi/setup.sh
@@ -99,6 +99,7 @@ cd ~
 
 wget -N $REPO_PATH/home/pi/.bashrc
 wget -N $REPO_PATH/home/pi/auto_run.sh
+wget -N $REPO_PATH/home/pi/mic_monitor.py
 wget -N $REPO_PATH/home/pi/mycroft.fb
 
 mkdir -p ~/bin


### PR DESCRIPTION
* Description of what the PR does, such as fixes # {issue number}
Watches mic level file for changes. If there are no changes and the mic is not muted we restart the voice process. This is essentially a 5 line script from @forslund that I expanded to 80 for no good reason. 😄 Thanks Ake!

* Description of how to validate or test this PR
You can unplug the mic array if you have Frankencroft and watchdog will restart voice process. `tail -f /var/log/mycroft/mic_monitor.log`. The mark-2-pi skill will throw some errors due to the disconnection, but you can see that it works.

* Whether you have signed a CLA (Contributor Licensing Agreement)
:+1:
