### PR TITLE
Switch from IS_TRAVIS to CI

### DIFF
--- a/home/pi/base_setup.sh
+++ b/home/pi/base_setup.sh
@@ -33,7 +33,7 @@ sudo apt-get install -y mycroft-wifi-setup
 # mycroft-core
 git clone https://github.com/MycroftAI/mycroft-core.git
 cd mycroft-core
-IS_TRAVIS=true bash dev_setup.sh 2>&1 | tee ../build.log
+CI=true bash dev_setup.sh 2>&1 | tee ../build.log
 # Keep for now.
 #rm ../build.log
 cd ~

--- a/home/pi/setup.sh
+++ b/home/pi/setup.sh
@@ -31,7 +31,7 @@ fi
 # Update mycroft-core 
 cd mycroft-core
 git pull
-IS_TRAVIS=true bash dev_setup.sh 2>&1 | tee ../dev_setup.log
+CI=true bash dev_setup.sh 2>&1 | tee ../dev_setup.log
 cd ~
 
 # Correct permissions from Mark 1 (which used the 'mycroft' user to run)


### PR DESCRIPTION
Core has [switched](https://github.com/MycroftAI/mycroft-core/pull/2252) from using `IS_TRAVIS` to `CI` which is a built in env for Travis, Jenkins, etc.

