### PR TITLE
Feature/package install

### DIFF
--- a/home/pi/auto_run.sh
+++ b/home/pi/auto_run.sh
@@ -29,8 +29,6 @@ function screen_logo() {
     cat mycroft.fb > /dev/fb0
 }
 
-export PATH="$HOME/bin:$HOME/mycroft-core/bin:$PATH"
-
 source mycroft-core/venv-activate.sh -q
 
 if [ "$SSH_CLIENT" == "" ] && [ "$(/usr/bin/tty)" = "/dev/tty1" ];
@@ -42,16 +40,6 @@ then
 
     # Set audio output volume to a reasonable level initially
     sudo i2cset -y 1 0x4b 25
-
-    # Launch pulseaudio if needed
-    if ! pidof pulseaudio > /dev/null; then
-        pulseaudio -D
-        sleep 1
-    fi
-
-    # Launch Mycroft Services ======================
-    bash "$HOME/mycroft-core/start-mycroft.sh" all > /dev/null 2>&1
-    python mic_monitor.py >> /var/log/mycroft/mic_monitor.log  2>&1 &
 else
     # running in SSH session
     echo

--- a/home/pi/base_setup.sh
+++ b/home/pi/base_setup.sh
@@ -29,11 +29,6 @@ sudo rm -rf /opt/venvs/mycroft-core/
 # Update mycroft-wifi-setup so update does not reinstall mycroft-core package
 sudo apt-get update -y
 sudo apt-get install -y mycroft-wifi-setup
+sudo apt-get install -y mycroft-mark2
 
-# mycroft-core
-git clone https://github.com/MycroftAI/mycroft-core.git
-cd mycroft-core
-CI=true bash dev_setup.sh 2>&1 | tee ../build.log
-# Keep for now.
-#rm ../build.log
 cd ~

--- a/home/pi/setup.sh
+++ b/home/pi/setup.sh
@@ -28,12 +28,6 @@ if ! ((test)) ; then
     exit 1
 fi
 
-# Update mycroft-core 
-cd mycroft-core
-git pull
-CI=true bash dev_setup.sh 2>&1 | tee ../dev_setup.log
-cd ~
-
 # Correct permissions from Mark 1 (which used the 'mycroft' user to run)
 sudo chown -R pi:pi /var/log/mycroft
 rm /var/log/mycroft/*

--- a/home/pi/setup.sh
+++ b/home/pi/setup.sh
@@ -39,6 +39,42 @@ rm -rf /opt/mycroft/skills/*
 # Locale fix
 sudo sed -i.bak 's|AcceptEnv LANG LC_\*||' /etc/ssh/sshd_config
 
+DEFAULT_PA="/etc/pulse/default.pa"
+PULSE_CLIENT="/etc/pulse/client.conf"
+
+function update_pulse_default_pa () {
+    if grep -q "Mycroft additions 0.1" ${DEFAULT_PA} ; then
+        echo "Updating pulse default.pa"
+        # Remove old changes
+        sed -i '/Mycroft additions 0.1/Q' ${DEFAULT_PA}
+
+        cat >> ${DEFAULT_PA} <<- EOF
+## Mycroft additions 0.2 Start
+## Mycroft additions End
+EOF
+    else
+        echo "${DEFAULT_PA} is already patched"
+    fi
+}
+
+
+function update_pulse_client () {
+    if grep -q "Mycroft additions 0.1" ${PULSE_CLIENT} ; then
+        echo "Updateing pulse client.conf"
+        # Remove old changes
+        sed -i '/Mycroft additions 0.1/Q' ${PULSE_CLIENT}
+        cat >> ${PULSE_CLIENT} <<- EOF
+## Mycroft additions 0.2 Start
+## Mycroft additions End
+EOF
+    else
+        echo "${PULSE_CLIENT} is already patched"
+    fi
+}
+
+update_pulse_default_pa
+update_pulse_pulse_client
+
 # Audio Setup
 sudo echo "# Mycroft Mark 2 Pi Audio Settings" | sudo tee -a /etc/pulse/daemon.conf
 sudo echo "resample-method = ffmpeg" | sudo tee -a /etc/pulse/daemon.conf


### PR DESCRIPTION
Installs mycroft-core via the mycroft-mark2 package. should if all goes well start up the services via the systemd services.

Everything is very basic but it hopefully works if only barely

Things that may be wonky:
- launching pulseaudio automatically.
- systemd service starts
Should be installed in `/lib/systemd/system/mycroft-*.service` and should be startable using commands similar to `systemctl start mycroft-messagebus`

